### PR TITLE
Trimming of template values

### DIFF
--- a/MwParserFromScratch/MwParserUtility.cs
+++ b/MwParserFromScratch/MwParserUtility.cs
@@ -33,6 +33,26 @@ namespace MwParserFromScratch
             return argumentName.Trim();
         }
 
+        /// <summary>
+        /// Normalizes and manipulates a template argument name or value.
+        /// </summary>
+        /// <inheritdoc cref="NormalizeTemplateArgumentText(Wikitext)"/>
+        /// <param name="text">The wikitext to be manipulated.</param>
+        internal static void NormalizeTemplateArgumentText(Wikitext text)
+        {
+            if (text.Lines.First() is Paragraph firstParagraph)
+            {
+                if (firstParagraph.Inlines.First() is PlainText firstPlainText)
+                    firstPlainText.Content = firstPlainText.Content.TrimStart();
+            }
+
+            if (text.Lines.Last() is Paragraph lastParagraph)
+            {
+                if (lastParagraph.Inlines.Last() is PlainText lastPlainText)
+                    lastPlainText.Content = lastPlainText.Content.TrimEnd();
+            }
+        }
+
         /// <inheritdoc cref="NormalizeImageLinkArgumentName(string)"/>
         /// <param name="argumentName">The argument name to be normalized. The node will be converted into its string representation.</param>
         public static string NormalizeImageLinkArgumentName(Node argumentName)
@@ -80,7 +100,7 @@ namespace MwParserFromScratch
         public static string NormalizeTitle(string title)
         {
             if (string.IsNullOrEmpty(title)) return title;
-            var parts = title.Split(new[] {':'}, 2);
+            var parts = title.Split(new[] { ':' }, 2);
             for (int i = 0; i < parts.Length; i++)
                 parts[i] = Utility.NormalizeTitlePart(parts[i], false);
             return string.Join(":", parts);

--- a/MwParserFromScratch/ParserCore.Expandable.cs
+++ b/MwParserFromScratch/ParserCore.Expandable.cs
@@ -164,6 +164,9 @@ namespace MwParserFromScratch
                 CurrentContext.Terminator = null;
                 var value = ParseWikitext();
                 Debug.Assert(value != null);
+
+                MwParserUtility.NormalizeTemplateArgumentText(value);
+
                 return ParseSuccessful(new TemplateArgument(a, value));
             }
             return ParseSuccessful(new TemplateArgument(null, a));
@@ -287,7 +290,7 @@ namespace MwParserFromScratch
                 return true;
             }
             closingTagMatch = matcher.Match(closingTag);
-            CLOSE_TAG:
+        CLOSE_TAG:
             Debug.Assert(closingTagMatch.Success);
             Debug.Assert(closingTagMatch.Groups[1].Success);
             Debug.Assert(closingTagMatch.Groups[2].Success);


### PR DESCRIPTION
Depending on how template parameters have been typed, there may are trailing white-spaces and/or line-breaks.

The wiki editor automatically gets rid of them. 