### PR TITLE
Fix INodeCollection.InsertAfter implementation

### DIFF
--- a/MwParserFromScratch/Nodes/NodeCollection.cs
+++ b/MwParserFromScratch/Nodes/NodeCollection.cs
@@ -256,7 +256,7 @@ namespace MwParserFromScratch.Nodes
 
         void INodeCollection.InsertAfter(Node node, Node newNode)
         {
-            InsertBefore((TNode) node, (TNode) newNode);
+            InsertAfter((TNode) node, (TNode) newNode);
         }
 
         bool INodeCollection.Remove(Node item)


### PR DESCRIPTION
The method `InsertAfter` of the `INodeCollection` interface was not implemented properly in the `NodeCollection` class due to a mistake.